### PR TITLE
Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx
 RUN mkdir -p /munki_repo
 Run mkdir -p /etc/nginx/sites-enabled/
-ADD nginx.conf /etc/nginx.conf
+ADD nginx.conf /etc/nginx/nginx.conf
 ADD munki-repo.conf /etc/nginx/sites-enabled/
 VOLUME /munki_repo
 EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,4 @@
 # stay in the foreground so Docker has a process to track
-daemon off;
 worker_processes 1;
 http {
     include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
In nginx 1.7.9, with latest base nginx image from Docker, it already turns off daemon at the command line. Specifying "daemon off;" as a directive in nginx.conf causes nginx not to start with the following error: 
[emerg] 1#0: "daemon" directive is duplicate in /etc/nginx/nginx.conf:2
nginx: [emerg] "daemon" directive is duplicate in /etc/nginx/nginx.conf:2

Removing "daemon off" from the nginx.conf fixes the issue.  Apparently nginx doesn't like duplicate directives.

In addition, the base nginx image uses /etc/nginx/nginx.conf, instead of /etc/nginx.conf.  Both of these issues have been addressed in this pull request.
